### PR TITLE
Disable warning 4996 (deprecated function use) in Visual C++.

### DIFF
--- a/selene/io/FileReader.hpp
+++ b/selene/io/FileReader.hpp
@@ -7,6 +7,11 @@
 
 /// @file
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
 #include <selene/base/Assert.hpp>
 
 #include <cerrno>
@@ -341,5 +346,9 @@ inline std::size_t read(FileReader& source, T* values, std::size_t nr_values) no
 }
 
 }  // namespace sln
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif  // SELENE_IO_FILE_READER_HPP

--- a/selene/io/FileWriter.hpp
+++ b/selene/io/FileWriter.hpp
@@ -7,6 +7,11 @@
 
 /// @file
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
+
 #include <selene/base/Assert.hpp>
 #include <selene/io/WriterMode.hpp>
 
@@ -352,5 +357,9 @@ inline std::size_t write(FileWriter& sink, const T* values, std::size_t nr_value
 }
 
 }  // namespace sln
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif  // SELENE_IO_FILE_WRITER_HPP


### PR DESCRIPTION
Due to use of std::fopen, etc.