### PR TITLE
Set cmake policy CMP0110 explicitly to avoid warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 project(selene VERSION 0.3.1 LANGUAGES CXX C)
+cmake_policy(SET CMP0110 NEW)
 
 # User-settable options
 option(SELENE_BUILD_TESTS "Build Selene tests" OFF)


### PR DESCRIPTION
Using cmake `3.23.3` when building selene from source I see many repeated warnings like:

```
CMake Warning (dev) in test/CMakeLists.txt:
  Policy CMP0110 is not set: add_test() supports arbitrary characters in test
  names.  Run "cmake --help-policy CMP0110" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  The following name given to add_test() is invalid if CMP0110 is not set or
  set to OLD:

    `"selene_tests:Image view creation"´

This warning is for project developers.  Use -Wno-dev to suppress it.
```

The warning is repeated so many times its difficult to make sense of the other cmake output. So I thought it would be worth providing a PR fixing this issue. Happy to amend this change to do it differently, but for me this change allowed the warnings to be silenced.

/cc @kmhofmann 