### PR TITLE
Fix tiff deprecation warnings

### DIFF
--- a/selene/img_io/tiff/Read.cpp
+++ b/selene/img_io/tiff/Read.cpp
@@ -29,16 +29,16 @@ namespace sln {
 
 namespace {
 
-TIFFAuxiliaryInfo get_tiff_auxiliary_info(TIFF* tif, uint16 bits_per_sample)
+TIFFAuxiliaryInfo get_tiff_auxiliary_info(TIFF* tif, std::uint16_t bits_per_sample)
 {
   using impl::tiff::get_field;
   using impl::tiff::get_string_field;
-  const auto min_sample_value = get_field<uint16>(tif, TIFFTAG_MINSAMPLEVALUE, uint16{0});
-  const auto max_sample_value = get_field<uint16>(tif, TIFFTAG_MAXSAMPLEVALUE,
-                                                  static_cast<uint16>(sln::power(uint16{2}, bits_per_sample) - 1));
+  const auto min_sample_value = get_field<std::uint16_t>(tif, TIFFTAG_MINSAMPLEVALUE, std::uint16_t{0});
+  const auto max_sample_value = get_field<std::uint16_t>(tif, TIFFTAG_MAXSAMPLEVALUE,
+                                                  static_cast<std::uint16_t>(sln::power(std::uint16_t{2}, bits_per_sample) - 1));
   const auto x_resolution = get_field<float>(tif, TIFFTAG_XRESOLUTION, 1.0f);
   const auto y_resolution = get_field<float>(tif, TIFFTAG_YRESOLUTION, 1.0f);
-  const auto resolution_unit = get_field<uint16>(tif, TIFFTAG_RESOLUTIONUNIT, RESUNIT_INCH);
+  const auto resolution_unit = get_field<std::uint16_t>(tif, TIFFTAG_RESOLUTIONUNIT, RESUNIT_INCH);
 
   auto software = get_string_field(tif, TIFFTAG_SOFTWARE);
   auto date_time = get_string_field(tif, TIFFTAG_DATETIME);
@@ -58,21 +58,21 @@ TiffImageLayout get_tiff_layout(TIFF* tif)
 {
   using impl::tiff::get_field;
   using impl::tiff::get_field_2;
-  const auto width = get_field<uint32>(tif, TIFFTAG_IMAGEWIDTH);
-  const auto height = get_field<uint32>(tif, TIFFTAG_IMAGELENGTH);
-  const auto depth = get_field<uint32>(tif, TIFFTAG_IMAGEDEPTH, 1);
+  const auto width = get_field<std::uint32_t>(tif, TIFFTAG_IMAGEWIDTH);
+  const auto height = get_field<std::uint32_t>(tif, TIFFTAG_IMAGELENGTH);
+  const auto depth = get_field<std::uint32_t>(tif, TIFFTAG_IMAGEDEPTH, 1);
 
-  const auto samples_per_pixel = get_field<uint16>(tif, TIFFTAG_SAMPLESPERPIXEL);
-  const auto bits_per_sample = get_field<uint16>(tif, TIFFTAG_BITSPERSAMPLE);
-  const auto planar_config = get_field<uint16>(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
-  const auto photometric = get_field<uint16>(tif, TIFFTAG_PHOTOMETRIC);
-  const auto sample_format = get_field<uint16>(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
-  const auto compression = get_field<uint16>(tif, TIFFTAG_COMPRESSION);
+  const auto samples_per_pixel = get_field<std::uint16_t>(tif, TIFFTAG_SAMPLESPERPIXEL);
+  const auto bits_per_sample = get_field<std::uint16_t>(tif, TIFFTAG_BITSPERSAMPLE);
+  const auto planar_config = get_field<std::uint16_t>(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+  const auto photometric = get_field<std::uint16_t>(tif, TIFFTAG_PHOTOMETRIC);
+  const auto sample_format = get_field<std::uint16_t>(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
+  const auto compression = get_field<std::uint16_t>(tif, TIFFTAG_COMPRESSION);
 
-  const auto orientation = get_field<uint16>(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
+  const auto orientation = get_field<std::uint16_t>(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
 
-  const auto subfile_type = get_field<uint32>(tif, TIFFTAG_SUBFILETYPE, uint32{0});
-  const auto page_number = get_field_2<uint16>(tif, TIFFTAG_PAGENUMBER, uint16{0});
+  const auto subfile_type = get_field<std::uint32_t>(tif, TIFFTAG_SUBFILETYPE, std::uint32_t{0});
+  const auto page_number = get_field_2<std::uint16_t>(tif, TIFFTAG_PAGENUMBER, std::uint16_t{0});
 
   auto auxiliary_info = get_tiff_auxiliary_info(tif, bits_per_sample);
 
@@ -104,8 +104,8 @@ get_tiff_color_conversion_structures(TIFF* tif)
   const auto ycbcr_coefficients_red = ycbcr_coefficients[0];
   const auto ycbcr_coefficients_green = ycbcr_coefficients[1];
   const auto ycbcr_coefficients_blue = ycbcr_coefficients[2];
-  const auto ycbcr_positioning = get_field<uint16>(tif, TIFFTAG_YCBCRPOSITIONING);
-  const auto ycbcr_subsampling = get_field_2<uint16>(tif, TIFFTAG_YCBCRSUBSAMPLING);
+  const auto ycbcr_positioning = get_field<std::uint16_t>(tif, TIFFTAG_YCBCRPOSITIONING);
+  const auto ycbcr_subsampling = get_field_2<std::uint16_t>(tif, TIFFTAG_YCBCRSUBSAMPLING);
   const auto ycbcr_subsampling_horz = ycbcr_subsampling.first;
   const auto ycbcr_subsampling_vert = ycbcr_subsampling.second;
   auto white_point_coefficients = get_field<float*>(tif, TIFFTAG_WHITEPOINT);

--- a/selene/img_io/tiff/Write.cpp
+++ b/selene/img_io/tiff/Write.cpp
@@ -36,26 +36,26 @@ void set_tiff_layout(TIFF* tif, const ConstantDynImageView& view, const TIFFWrit
 {
   using impl::tiff::set_field;
   using impl::tiff::set_string_field;
-  set_field<uint32>(tif, TIFFTAG_IMAGEWIDTH, static_cast<uint32>(view.width()));
-  set_field<uint32>(tif, TIFFTAG_IMAGELENGTH, static_cast<uint32>(view.height()));
-  set_field<uint32>(tif, TIFFTAG_IMAGEDEPTH, uint32{1});
+  set_field<std::uint32_t>(tif, TIFFTAG_IMAGEWIDTH, static_cast<std::uint32_t>(view.width()));
+  set_field<std::uint32_t>(tif, TIFFTAG_IMAGELENGTH, static_cast<std::uint32_t>(view.height()));
+  set_field<std::uint32_t>(tif, TIFFTAG_IMAGEDEPTH, uint32{1});
 
-  set_field<uint16>(tif, TIFFTAG_SAMPLESPERPIXEL, static_cast<uint16>(view.nr_channels()));
-  set_field<uint16>(tif, TIFFTAG_BITSPERSAMPLE, static_cast<uint16>(view.nr_bytes_per_channel() * 8));
-  set_field<uint16>(tif, TIFFTAG_PHOTOMETRIC, impl::tiff::pixel_format_to_photometric(view.pixel_format()));
-  set_field<uint16>(tif, TIFFTAG_SAMPLEFORMAT, impl::tiff::sample_format_to_sample_format(view.sample_format()));
+  set_field<std::uint16_t>(tif, TIFFTAG_SAMPLESPERPIXEL, static_cast<std::uint16_t>(view.nr_channels()));
+  set_field<std::uint16_t>(tif, TIFFTAG_BITSPERSAMPLE, static_cast<std::uint16_t>(view.nr_bytes_per_channel() * 8));
+  set_field<std::uint16_t>(tif, TIFFTAG_PHOTOMETRIC, impl::tiff::pixel_format_to_photometric(view.pixel_format()));
+  set_field<std::uint16_t>(tif, TIFFTAG_SAMPLEFORMAT, impl::tiff::sample_format_to_sample_format(view.sample_format()));
 
   if (view.pixel_format() == PixelFormat::RGBA)
   {
     // We need to specify the extra sample.
     std::array<uint16, 1> extra_sample_types = {{EXTRASAMPLE_ASSOCALPHA}};
-    set_field<uint16>(tif, TIFFTAG_EXTRASAMPLES, 1, extra_sample_types.data());
+    set_field<std::uint16_t>(tif, TIFFTAG_EXTRASAMPLES, 1, extra_sample_types.data());
   }
 
-  set_field<uint16>(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);  // we only write interleaved data
-  set_field<uint16>(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
+  set_field<std::uint16_t>(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);  // we only write interleaved data
+  set_field<std::uint16_t>(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
 
-  set_field<uint16>(tif, TIFFTAG_COMPRESSION, impl::tiff::compression_pub_to_lib(write_options.compression_type));
+  set_field<std::uint16_t>(tif, TIFFTAG_COMPRESSION, impl::tiff::compression_pub_to_lib(write_options.compression_type));
   if (write_options.compression_type == TIFFCompression::JPEG)
   {
     set_field<int>(tif, TIFFTAG_JPEGQUALITY, write_options.jpeg_quality);
@@ -76,15 +76,15 @@ void set_tiff_layout_tiles(TIFF* tif, std::size_t tile_width, std::size_t tile_h
 {
   using impl::tiff::set_field;
   SELENE_ASSERT(tile_width % 8 == 0 && tile_height % 8 == 0);
-  set_field<uint32>(tif, TIFFTAG_TILEWIDTH, static_cast<uint32>(tile_width));
-  set_field<uint32>(tif, TIFFTAG_TILELENGTH, static_cast<uint32>(tile_height));
-  set_field<uint32>(tif, TIFFTAG_TILEDEPTH, uint32{1});
+  set_field<std::uint32_t>(tif, TIFFTAG_TILEWIDTH, static_cast<std::uint32_t>(tile_width));
+  set_field<std::uint32_t>(tif, TIFFTAG_TILELENGTH, static_cast<std::uint32_t>(tile_height));
+  set_field<std::uint32_t>(tif, TIFFTAG_TILEDEPTH, uint32{1});
 }
 
 bool check_tiff_tile_size(TIFF* tif, const ConstantDynImageView& /*view*/, TIFFWriteOptions& opts, MessageLog& /*message_log*/)
 {
-  auto tw = static_cast<uint32>(opts.tile_width);
-  auto th = static_cast<uint32>(opts.tile_height);
+  auto tw = static_cast<std::uint32_t>(opts.tile_width);
+  auto th = static_cast<std::uint32_t>(opts.tile_height);
   TIFFDefaultTileSize(tif, &tw, &th);
   opts.tile_width = static_cast<std::size_t>(tw);
   opts.tile_height = static_cast<std::size_t>(th);
@@ -242,7 +242,7 @@ bool tiff_write_to_current_directory_strips(TIFF* tif, const TIFFWriteOptions& w
       return buffer.data();
     }();
 
-    tstrip_t strip = TIFFComputeStrip(tif, static_cast<uint32>(cur_row), 0);
+    tstrip_t strip = TIFFComputeStrip(tif, static_cast<std::uint32_t>(cur_row), 0);
     SELENE_ASSERT(static_cast<std::size_t>(strip) == strip_idx);
 
     auto size_written = TIFFWriteEncodedStrip(tif, strip, const_cast<void*>(static_cast<const void*>(buf_ptr)), buf_size);
@@ -272,13 +272,13 @@ bool tiff_write_to_current_directory_tiles(TIFF* tif, const TIFFWriteOptions& wr
   std::vector<std::uint8_t> buffer(tile_width * tile_height * to_unsigned(nr_bytes_per_pixel));
 
   // For each tile...
-  uint32 tile_ctr = 0;
+  std::uint32_t tile_ctr = 0;
   for (auto src_y = 0_idx; src_y < height; src_y += to_pixel_index(tile_height))
   {
     for (auto src_x = 0_idx; src_x < width; src_x += to_pixel_index(tile_width))
     {
-      const auto x = static_cast<uint32>(src_x);
-      const auto y = static_cast<uint32>(src_y);
+      const auto x = static_cast<std::uint32_t>(src_x);
+      const auto y = static_cast<std::uint32_t>(src_y);
       uint16 sample = 0;
       const auto tile_idx = TIFFComputeTile(tif, x, y, uint32{0}, sample);
       SELENE_ASSERT(tile_idx == tile_ctr); // ???
@@ -333,8 +333,8 @@ bool tiff_write_to_current_directory(TIFFWriteObject<SinkType>& tiff_obj,
     // This is necessary to write a multi-page TIFF, i.e. with multiple directories.
     // The only tangible information that can be found on the web about this seems to be here:
     // https://www.asmail.be/msg0055065771.html
-    impl::tiff::set_field<uint32>(tif, TIFFTAG_SUBFILETYPE, FILETYPE_PAGE);
-    impl::tiff::set_field<uint16>(tif, TIFFTAG_PAGENUMBER, static_cast<uint16_t>(directory_index), uint16_t{0});
+    impl::tiff::set_field<std::uint32_t>(tif, TIFFTAG_SUBFILETYPE, FILETYPE_PAGE);
+    impl::tiff::set_field<std::uint16_t>(tif, TIFFTAG_PAGENUMBER, static_cast<std::uint16_t>(directory_index), std::uint16_t{0});
   }
 
   if (write_options.layout == TIFFWriteOptions::Layout::Strips)

--- a/selene/img_io/tiff/_impl/TIFFDetail.cpp
+++ b/selene/img_io/tiff/_impl/TIFFDetail.cpp
@@ -522,7 +522,7 @@ std::vector<std::uint8_t> convert_ycbcr_to_rgb_interleaved(const std::vector<std
   std::vector<std::uint8_t> out_buf(3 * width * height);
   sln::MutableImageView_8u3 out_img(out_buf.data(), {sln::to_pixel_length(width), sln::to_pixel_length(height)});
 
-  std::vector<uint32> y_data_unit(sh * sv);
+  std::vector<std::uint32_t> y_data_unit(sh * sv);
   for (std::uint32_t y = 0; y < height; y += sv)
   {
     for (std::uint32_t x = 0; x < width; x += sh)
@@ -530,8 +530,8 @@ std::vector<std::uint8_t> convert_ycbcr_to_rgb_interleaved(const std::vector<std
       // https://www.awaresystems.be/imaging/tiff/specification/TIFF6.pdf#page=93
       // Read "data unit" of sv * sh Y values, followed by Cb and Cr values
       std::generate(y_data_unit.begin(), y_data_unit.end(), consume_buf);
-      const int32 Cb = consume_buf();
-      const int32 Cr = consume_buf();
+      const std::int32_t Cb = consume_buf();
+      const std::int32_t Cr = consume_buf();
 
       SELENE_ASSERT(buf_ptr <= buf.data() + nr_bytes_read);
 
@@ -539,9 +539,9 @@ std::vector<std::uint8_t> convert_ycbcr_to_rgb_interleaved(const std::vector<std
       {
         for (std::uint32_t dx = 0; dx < sh; ++dx)
         {
-          uint32 r = 0;
-          uint32 g = 0;
-          uint32 b = 0;
+          std::uint32_t r = 0;
+          std::uint32_t g = 0;
+          std::uint32_t b = 0;
           const auto Y = y_data_unit[dy * sh + dx];
           ycbcr_converter.convert(Y, Cb, Cr, r, g, b);
           out_img(sln::to_pixel_index(x + dx), sln::to_pixel_index(y + dy))
@@ -573,12 +573,12 @@ std::vector<std::uint8_t> convert_lab_to_rgb_interleaved(const std::vector<std::
   const auto out_buf_end = out_buf.data() + out_buf.size();
   while (out_buf_ptr < out_buf_end)
   {
-    const uint32 lab_L = *buf_ptr++;
-    const int32 lab_a = *buf_ptr++;
-    const int32 lab_b = *buf_ptr++;
-    uint32 r;
-    uint32 g;
-    uint32 b;
+    const std::uint32_t lab_L = *buf_ptr++;
+    const std::int32_t lab_a = *buf_ptr++;
+    const std::int32_t lab_b = *buf_ptr++;
+    std::uint32_t r;
+    std::uint32_t g;
+    std::uint32_t b;
     lab_converter.convert(lab_L, lab_a, lab_b, r, g, b);
     *out_buf_ptr++ = static_cast<std::uint8_t>(r);
     *out_buf_ptr++ = static_cast<std::uint8_t>(g);

--- a/selene/img_io/tiff/_impl/TIFFDetail.hpp
+++ b/selene/img_io/tiff/_impl/TIFFDetail.hpp
@@ -66,7 +66,7 @@ std::string sample_format_to_string(std::uint16_t value);
 std::string compression_to_string(std::uint16_t value);
 std::string orientation_to_string(std::uint16_t value);
 
-template <typename T> T get_field(TIFF* tif, uint32 tag)
+template <typename T> T get_field(TIFF* tif, std::uint32_t tag)
 {
   T var{};
   [[maybe_unused]] const int val = TIFFGetFieldDefaulted(tif, tag, &var);
@@ -74,14 +74,14 @@ template <typename T> T get_field(TIFF* tif, uint32 tag)
   return var;
 }
 
-template <typename T> T get_field(TIFF* tif, uint32 tag, T default_value)
+template <typename T> T get_field(TIFF* tif, std::uint32_t tag, T default_value)
 {
   T var{};
   const auto val = TIFFGetFieldDefaulted(tif, tag, &var);
   return (val == 1) ? var : default_value;
 }
 
-template <typename T> std::pair<T, T> get_field_2(TIFF* tif, uint32 tag)
+template <typename T> std::pair<T, T> get_field_2(TIFF* tif, std::uint32_t tag)
 {
   T var0{}, var1{};
   [[maybe_unused]] const int val = TIFFGetFieldDefaulted(tif, tag, &var0, &var1);
@@ -89,14 +89,14 @@ template <typename T> std::pair<T, T> get_field_2(TIFF* tif, uint32 tag)
   return std::make_pair(var0, var1);
 }
 
-template <typename T> std::pair<T, T> get_field_2(TIFF* tif, uint32 tag, T default_value)
+template <typename T> std::pair<T, T> get_field_2(TIFF* tif, std::uint32_t tag, T default_value)
 {
   T var0{}, var1{};
   const int val = TIFFGetFieldDefaulted(tif, tag, &var0, &var1);
   return (val == 1) ? std::make_pair(var0, var1) : std::make_pair(default_value, default_value);
 }
 
-inline std::string get_string_field(TIFF* tif, uint32 tag)
+inline std::string get_string_field(TIFF* tif, std::uint32_t tag)
 {
   char* buf = nullptr;
   const int val = TIFFGetFieldDefaulted(tif, tag, &buf);
@@ -108,13 +108,13 @@ inline std::string get_string_field(TIFF* tif, uint32 tag)
 }
 
 template <typename... Ts>
-inline void set_field(TIFF* tif, uint32 tag, Ts... values)
+inline void set_field(TIFF* tif, std::uint32_t tag, Ts... values)
 {
   [[maybe_unused]] int res = TIFFSetField(tif, tag, values...);
   SELENE_ASSERT(res != 0);
 }
 
-inline void set_string_field(TIFF* tif, uint32 tag, const std::string& str)
+inline void set_string_field(TIFF* tif, std::uint32_t tag, const std::string& str)
 {
   [[maybe_unused]] int res = TIFFSetField(tif, tag, str.c_str());
   SELENE_ASSERT(res != 0);
@@ -122,11 +122,11 @@ inline void set_string_field(TIFF* tif, uint32 tag, const std::string& str)
 
 struct ImageLayoutStrips
 {
-  uint32 nr_strips;
+  std::uint32_t nr_strips;
   tmsize_t size_bytes;
-  uint32 rows_per_strip;
+  std::uint32_t rows_per_strip;
 
-  ImageLayoutStrips(uint32 nr_strips_, tmsize_t strip_size_, uint32 rows_per_strip_)
+  ImageLayoutStrips(std::uint32_t nr_strips_, tmsize_t strip_size_, std::uint32_t rows_per_strip_)
       : nr_strips(nr_strips_), size_bytes(strip_size_), rows_per_strip(rows_per_strip_)
   {
   }
@@ -134,13 +134,13 @@ struct ImageLayoutStrips
 
 struct ImageLayoutTiles
 {
-  uint32 width;
-  uint32 height;
-  uint32 depth;
+  std::uint32_t width;
+  std::uint32_t height;
+  std::uint32_t depth;
 
   tmsize_t size_bytes;
 
-  ImageLayoutTiles(uint32 tile_width, uint32 tile_height, uint32 tile_depth, tmsize_t tile_size)
+  ImageLayoutTiles(std::uint32_t tile_width, std::uint32_t tile_height, std::uint32_t tile_depth, tmsize_t tile_size)
       : width(tile_width), height(tile_height), depth(tile_depth), size_bytes(tile_size)
   {
     SELENE_ASSERT(depth == 1);
@@ -152,18 +152,18 @@ struct YCbCrInfo
   float coeff_red;
   float coeff_green;
   float coeff_blue;
-  uint16 positioning;
-  uint16 subsampling_horz;
-  uint16 subsampling_vert;
+  std::uint16_t positioning;
+  std::uint16_t subsampling_horz;
+  std::uint16_t subsampling_vert;
 
-  YCbCrInfo(float coeff_red_, float coeff_green_, float coeff_blue_, uint16 positioning_,
-                uint16 subsampling_horz_, uint16 subsampling_vert_)
+  YCbCrInfo(float coeff_red_, float coeff_green_, float coeff_blue_, std::uint16_t positioning_,
+                std::uint16_t subsampling_horz_, std::uint16_t subsampling_vert_)
       : coeff_red(coeff_red_), coeff_green(coeff_green_), coeff_blue(coeff_blue_), positioning(positioning_),
         subsampling_horz(subsampling_horz_), subsampling_vert(subsampling_vert_)
   {
   }
 
-  bool check_strip_size(uint32 width, uint32 height, uint32 rows_per_strip, MessageLog& message_log) const
+  bool check_strip_size(std::uint32_t width, std::uint32_t height, std::uint32_t rows_per_strip, MessageLog& message_log) const
   {
     bool subsample_pars_check = check_subsampling_parameters(message_log);
     bool size_pars_check = check_size(width, height, message_log);
@@ -182,7 +182,7 @@ struct YCbCrInfo
     return true;
   }
 
-  bool check_tile_size(uint32 width, uint32 height, uint32 tile_width, uint32 tile_height, MessageLog& message_log) const
+  bool check_tile_size(std::uint32_t width, std::uint32_t height, std::uint32_t tile_width, std::uint32_t tile_height, MessageLog& message_log) const
   {
     bool subsample_pars_check = check_subsampling_parameters(message_log);
     bool size_pars_check = check_size(width, height, message_log);
@@ -226,7 +226,7 @@ private:
     return true;
   }
 
-  [[nodiscard]] bool check_size(uint32 width, uint32 height, MessageLog& message_log) const
+  [[nodiscard]] bool check_size(std::uint32_t width, std::uint32_t height, MessageLog& message_log) const
   {
     if (width % subsampling_horz != 0 || height % subsampling_vert != 0)
     {
@@ -244,7 +244,7 @@ public:
   YCbCrConverter(float* ycbcr_coefficients, float* reference_blackwhite)
   {
     ycbcr_ = (TIFFYCbCrToRGB*)_TIFFmalloc(std::max(sizeof(TIFFYCbCrToRGB), sizeof(long))
-                                          + 4*256*sizeof(TIFFRGBValue) + 2*256*sizeof(int) + 3*256*sizeof(int32));
+                                          + 4*256*sizeof(TIFFRGBValue) + 2*256*sizeof(int) + 3*256*sizeof(std::int32_t));
     SELENE_ASSERT(ycbcr_ != nullptr);
     [[maybe_unused]] const auto success = TIFFYCbCrToRGBInit(ycbcr_, ycbcr_coefficients, reference_blackwhite);
     SELENE_ASSERT(success >= 0);
@@ -274,7 +274,7 @@ public:
     return *this;
   }
 
-  void convert(uint32 Y, int32 Cb, int32 Cr, uint32& r, uint32& g, uint32& b) const
+  void convert(std::uint32_t Y, std::int32_t Cb, std::int32_t Cr, std::uint32_t& r, std::uint32_t& g, std::uint32_t& b) const
   {
     TIFFYCbCrtoRGB(ycbcr_, Y, Cb, Cr, &r, &g, &b);
   }
@@ -330,7 +330,7 @@ public:
     return *this;
   }
 
-  void convert(uint32 lab_L, int32 lab_a, int32 lab_b, uint32& r, uint32& g, uint32& b) const
+  void convert(std::uint32_t lab_L, std::int32_t lab_a, std::int32_t lab_b, std::uint32_t& r, std::uint32_t& g, std::uint32_t& b) const
   {
     float X;
     float Y;

--- a/selene/img_io/tiff/_impl/TIFFReadStrips.cpp
+++ b/selene/img_io/tiff/_impl/TIFFReadStrips.cpp
@@ -83,7 +83,7 @@ bool read_data_strips_interleaved(TIFF* tif,
           std::to_string(expected_nr_bytes) + ")", MessageType::Warning);
     }
 
-    const auto rows_in_this_strip = static_cast<uint32>(strip_layout.rows_per_strip * nr_bytes_read / expected_nr_bytes);
+    const auto rows_in_this_strip = static_cast<std::uint32_t>(strip_layout.rows_per_strip * nr_bytes_read / expected_nr_bytes);
 
     // Modify the buffer, if necessary
 
@@ -265,9 +265,9 @@ sln::impl::tiff::OutputLayout get_output_layout(TIFF* tif,
                                     + ((src.height % strip_layout.rows_per_strip) ? 1 : 0);
 
   // do some sanity checks that strip layout is as expected
-  for (uint16 sample = 0; sample < spp; ++sample)
+  for (std::uint16_t sample = 0; sample < spp; ++sample)
   {
-    for (uint32 row = 0; row < src.height; ++row)
+    for (std::uint32_t row = 0; row < src.height; ++row)
     {
       [[maybe_unused]] const auto strip_index = TIFFComputeStrip(tif, row, sample);
       [[maybe_unused]] const auto expected_strip_index = sample * nr_strips_per_sample + (row / strip_layout.rows_per_strip);
@@ -307,7 +307,7 @@ bool read_data_strips(TIFF* tif,
                       DynImageOrView& dyn_img_or_view,
                       sln::MessageLog& message_log)
 {
-  const auto nr_rows_per_strip = std::min(src.height, impl::tiff::get_field<uint32>(tif, TIFFTAG_ROWSPERSTRIP));
+  const auto nr_rows_per_strip = std::min(src.height, impl::tiff::get_field<std::uint32_t>(tif, TIFFTAG_ROWSPERSTRIP));
   const sln::impl::tiff::ImageLayoutStrips strip_layout(TIFFNumberOfStrips(tif), TIFFStripSize(tif), nr_rows_per_strip);
 
   const auto out = get_output_layout(tif, src, ycbcr_info, strip_layout, message_log);

--- a/selene/img_io/tiff/_impl/TIFFReadTiles.cpp
+++ b/selene/img_io/tiff/_impl/TIFFReadTiles.cpp
@@ -45,7 +45,7 @@ bool read_data_tiles_interleaved(TIFF* tif,
     ycbcr_info.check_tile_size(src.width, src.height, tile_layout.width, tile_layout.height, message_log);
   }
 
-  constexpr uint16 sample_index = 0;
+  constexpr std::uint16_t sample_index = 0;
 
   // For each tile...
   for (auto src_y = 0_idx; src_y < static_cast<value_type>(src.height); src_y += to_pixel_index(tile_layout.height))
@@ -54,7 +54,7 @@ bool read_data_tiles_interleaved(TIFF* tif,
     {
       // Read tile data into buffer
       std::vector<std::uint8_t> buf(static_cast<std::size_t>(tile_layout.size_bytes));
-      auto nr_bytes_read = TIFFReadTile(tif, buf.data(), static_cast<uint32>(src_x), static_cast<uint32>(src_y), 0, sample_index);
+      auto nr_bytes_read = TIFFReadTile(tif, buf.data(), static_cast<std::uint32_t>(src_x), static_cast<std::uint32_t>(src_y), 0, sample_index);
       SELENE_ASSERT(nr_bytes_read <= static_cast<std::ptrdiff_t>(buf.size()));
 
       if (nr_bytes_read < 0)
@@ -169,7 +169,7 @@ bool read_data_tiles_planar(TIFF* tif,
   SELENE_ASSERT(nr_channels == static_cast<std::int16_t>(src.samples_per_pixel));
   SELENE_ASSERT(nr_bytes_per_channel == static_cast<std::int16_t>(src.bits_per_sample >> 3));
 
-  for (uint16 sample_index = 0; sample_index < src.samples_per_pixel; ++sample_index)
+  for (std::uint16_t sample_index = 0; sample_index < src.samples_per_pixel; ++sample_index)
   {
     const auto width = to_pixel_index(src.width);
     const auto height = to_pixel_index(src.height);
@@ -179,7 +179,7 @@ bool read_data_tiles_planar(TIFF* tif,
       for (auto src_x = 0_idx; src_x < width; src_x += to_pixel_index(tile_layout.width))
       {
         std::vector<std::uint8_t> buf(static_cast<std::size_t>(tile_layout.size_bytes));
-        const auto nr_bytes_read = TIFFReadTile(tif, buf.data(), static_cast<uint32>(src_x), static_cast<uint32>(src_y), 0, sample_index);
+        const auto nr_bytes_read = TIFFReadTile(tif, buf.data(), static_cast<std::uint32_t>(src_x), static_cast<std::uint32_t>(src_y), 0, sample_index);
         SELENE_ASSERT(nr_bytes_read <= static_cast<std::ptrdiff_t>(buf.size()));
 
         if (nr_bytes_read < 0)
@@ -247,9 +247,9 @@ bool read_data_tiles(TIFF* tif,
                      sln::MessageLog& message_log)
 {
   const sln::impl::tiff::ImageLayoutTiles tile_layout(
-      impl::tiff::get_field<uint32>(tif, TIFFTAG_TILEWIDTH),
-      impl::tiff::get_field<uint32>(tif, TIFFTAG_TILELENGTH),
-      impl::tiff::get_field<uint32>(tif, TIFFTAG_TILEDEPTH, 1),
+      impl::tiff::get_field<std::uint32_t>(tif, TIFFTAG_TILEWIDTH),
+      impl::tiff::get_field<std::uint32_t>(tif, TIFFTAG_TILELENGTH),
+      impl::tiff::get_field<std::uint32_t>(tif, TIFFTAG_TILEDEPTH, 1),
       TIFFTileSize(tif));
 
 //  message_log.add(str(oss() << tile_layout), MessageType::Message);


### PR DESCRIPTION
This addresses the deprecation warnings coming from the latest tiff releases.

I saw them with `libtiff/4.4.0_1` from homebrew:

```
./projects/selene/selene/img_io/tiff/Write.cpp:41:53: warning: 'uint32' is deprecated [-Wdeprecated-declarations]
  set_field<std::uint32_t>(tif, TIFFTAG_IMAGEDEPTH, uint32{1});
                                                    ^
/opt/homebrew/include/tiff.h:84:45: note: 'uint32' has been explicitly marked deprecated here
typedef TIFF_MSC_DEPRECATED uint32_t uint32 TIFF_GCC_DEPRECATED;
                                            ^
```
/cc @kmhofmann 